### PR TITLE
Use numDisplays instead of MAX_DISPLAYS in hwcomposer reset() function

### DIFF
--- a/msm8974/libhwcomposer/hwc.cpp
+++ b/msm8974/libhwcomposer/hwc.cpp
@@ -89,7 +89,7 @@ static void hwc_registerProcs(struct hwc_composer_device_1* dev,
 //Helper
 static void reset(hwc_context_t *ctx, int numDisplays,
                   hwc_display_contents_1_t** displays) {
-    for(int i = 0; i < MAX_DISPLAYS; i++) {
+    for(int i = 0; i < numDisplays; i++) {
         hwc_display_contents_1_t *list = displays[i];
         // XXX:SurfaceFlinger no longer guarantees that this
         // value is reset on every prepare. However, for the layer


### PR DESCRIPTION
Using MAX_DISPLAYS instead of numDisplays was causing compositor to crash. This pull request fixes this issue.
